### PR TITLE
fix(harmonizer): add missing @id to foaf:primaryTopic

### DIFF
--- a/repo_harvester_server/helper/JMESPATHQueries.py
+++ b/repo_harvester_server/helper/JMESPATHQueries.py
@@ -21,6 +21,7 @@ DCAT_EXPORT_QUERY = '''
    "prov:label" : 'EDEN Catalog Service Harvester'
    },
    "foaf:primaryTopic": {
+  "@id": id,
   "@type": ['dcat:Catalog', 'foaf:Project'],
   "dct:type": resource_type || null,
   "dct:title": title,


### PR DESCRIPTION
## Summary

Adds the `@id` field to the `foaf:primaryTopic` object in the `DCAT_EXPORT_QUERY` JMESPATH template, so the harmonized graph's catalog entity is stored as a proper URI node instead of a blank node.

Fixes #24