### PR TITLE
fix(metadata): prevent double URL encoding of service endpoint URIs

### DIFF
--- a/repo_harvester_server/helper/MetadataHelper.py
+++ b/repo_harvester_server/helper/MetadataHelper.py
@@ -453,7 +453,7 @@ class MetadataHelper:
                         if service_res.get('endpoint_uri'):
                             if isinstance(service_res['endpoint_uri'], str):
                                 #safe identifiers e.g. replace curly urls in url patterns like: https://example.com?query={query_string}
-                                service_res['endpoint_uri'] = urllib.parse.quote(service_res['endpoint_uri'], safe=":/#?=&")
+                                service_res['endpoint_uri'] = urllib.parse.quote(service_res['endpoint_uri'], safe=":/#?=&%")
                                 if 'SearchAction' in str(service_res.get('type')):
                                     service_res['output_format'] = 'text/html'
                                     service_res['conforms_to'] = 'https://www.ietf.org/rfc/rfc2616' #http (default)


### PR DESCRIPTION
## Summary

Adds `%` to the `safe` parameter of `urllib.parse.quote()` in `MetadataHelper.get_jsonld_metadata_simple()`, so already-encoded percent sequences are preserved when the harmonizer re-processes URLs from Fuseki.

Fixes #25